### PR TITLE
Verify snap sync head header subscription

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10327,6 +10327,7 @@ dependencies = [
  "reth-db",
  "reth-db-api",
  "reth-downloaders",
+ "reth-engine-primitives",
  "reth-era",
  "reth-era-downloader",
  "reth-era-utils",

--- a/crates/stages/stages/Cargo.toml
+++ b/crates/stages/stages/Cargo.toml
@@ -31,6 +31,7 @@ reth-primitives-traits = { workspace = true, features = ["serde-bincode-compat"]
 reth-provider.workspace = true
 reth-execution-types.workspace = true
 reth-ethereum-primitives = { workspace = true, optional = true }
+reth-engine-primitives = { workspace = true, optional = true }
 reth-prune.workspace = true
 reth-prune-types.workspace = true
 reth-storage-errors.workspace = true
@@ -116,6 +117,7 @@ test-utils = [
     "reth-trie-db/test-utils",
     "reth-trie/test-utils",
     "reth-prune-types/test-utils",
+    "dep:reth-engine-primitives",
     "dep:reth-ethereum-primitives",
     "reth-ethereum-primitives?/test-utils",
     "reth-evm-ethereum/test-utils",

--- a/crates/stages/stages/src/stages/mod.rs
+++ b/crates/stages/stages/src/stages/mod.rs
@@ -21,6 +21,9 @@ mod prune;
 mod sender_recovery;
 /// The snap sync stage.
 mod snap_sync;
+/// Integration tests for snap sync with header subscription.
+#[cfg(test)]
+mod snap_sync_integration_test;
 /// The transaction lookup stage
 mod tx_lookup;
 

--- a/crates/stages/stages/src/stages/snap_sync/header_subscription.rs
+++ b/crates/stages/stages/src/stages/snap_sync/header_subscription.rs
@@ -1,0 +1,222 @@
+//! Header subscription mechanism for snap sync stage.
+//!
+//! This module provides a way to subscribe to head header updates from the consensus engine
+//! and make them available to the snap sync stage.
+
+use reth_engine_primitives::ConsensusEngineEvent;
+use reth_primitives_traits::{NodePrimitives, SealedHeader};
+use tokio::sync::{broadcast, watch};
+use tracing::{debug, warn};
+
+/// A header subscription service that listens to consensus engine events
+/// and provides the latest head header to subscribers.
+#[derive(Debug)]
+pub struct HeaderSubscriptionService<N> {
+    /// Broadcast sender for consensus engine events
+    event_sender: broadcast::Sender<ConsensusEngineEvent<N>>,
+    /// Watch sender for head header updates
+    header_sender: watch::Sender<Option<SealedHeader<N::BlockHeader>>>,
+    /// Current head header
+    current_header: Option<SealedHeader<N::BlockHeader>>,
+}
+
+impl<N> HeaderSubscriptionService<N>
+where
+    N: NodePrimitives<BlockHeader = alloy_consensus::Header>,
+{
+    /// Create a new header subscription service.
+    pub fn new(event_sender: broadcast::Sender<ConsensusEngineEvent<N>>) -> (Self, watch::Receiver<SealedHeader<N::BlockHeader>>) {
+        let (header_sender, header_receiver) = watch::channel(None);
+        
+        let service = Self {
+            event_sender,
+            header_sender,
+            current_header: None,
+        };
+        
+        (service, header_receiver)
+    }
+    
+    /// Start listening to consensus engine events and updating head headers.
+    pub async fn start(mut self) {
+        let mut event_receiver = self.event_sender.subscribe();
+        
+        debug!(target: "sync::stages::header_subscription", "Starting header subscription service");
+        
+        while let Ok(event) = event_receiver.recv().await {
+            if let Some(header) = self.handle_consensus_event(event) {
+                self.update_head_header(header).await;
+            }
+        }
+        
+        warn!(target: "sync::stages::header_subscription", "Header subscription service stopped");
+    }
+    
+    /// Handle a consensus engine event and extract head header if available.
+    fn handle_consensus_event(&mut self, event: ConsensusEngineEvent<N>) -> Option<SealedHeader<N::BlockHeader>> {
+        match event {
+            ConsensusEngineEvent::CanonicalChainCommitted(header, _) => {
+                debug!(
+                    target: "sync::stages::header_subscription",
+                    number = header.number(),
+                    hash = ?header.hash(),
+                    state_root = ?header.state_root,
+                    "Received canonical chain committed event"
+                );
+                Some(*header)
+            }
+            ConsensusEngineEvent::ForkchoiceUpdated(state, _) => {
+                debug!(
+                    target: "sync::stages::header_subscription",
+                    head_block_hash = ?state.head_block_hash,
+                    "Received forkchoice updated event"
+                );
+                // Note: ForkchoiceUpdated doesn't contain the header directly,
+                // but it indicates the head has changed. The actual header will
+                // come through CanonicalChainCommitted.
+                None
+            }
+            _ => {
+                // Other events don't contain head header information
+                None
+            }
+        }
+    }
+    
+    /// Update the head header and notify subscribers.
+    async fn update_head_header(&mut self, header: SealedHeader<N::BlockHeader>) {
+        // Check if this is actually a new header
+        if let Some(ref current) = self.current_header {
+            if current.hash() == header.hash() {
+                debug!(
+                    target: "sync::stages::header_subscription",
+                    hash = ?header.hash(),
+                    "Header already current, skipping update"
+                );
+                return;
+            }
+        }
+        
+        debug!(
+            target: "sync::stages::header_subscription",
+            old_header = ?self.current_header.as_ref().map(|h: &SealedHeader<N::BlockHeader>| h.num_hash()),
+            new_header = ?header.num_hash(),
+            "Updating head header"
+        );
+        
+        self.current_header = Some(header.clone());
+        
+        // Send the header to all subscribers
+        if let Err(e) = self.header_sender.send(Some(header)) {
+            warn!(
+                target: "sync::stages::header_subscription",
+                error = %e,
+                "Failed to send header update to subscribers"
+            );
+        }
+    }
+}
+
+/// A trait for types that can provide head header updates.
+pub trait HeaderProvider {
+    /// Get the current head header.
+    fn get_head_header(&self) -> Option<SealedHeader<Self::BlockHeader>>;
+    
+    /// The block header type.
+    type BlockHeader;
+}
+
+impl<N> HeaderProvider for HeaderSubscriptionService<N>
+where
+    N: reth_primitives_traits::NodePrimitives,
+{
+    type BlockHeader = N::BlockHeader;
+    
+    fn get_head_header(&self) -> Option<SealedHeader<Self::BlockHeader>> {
+        self.current_header.clone()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_consensus::BlockHeader;
+    use alloy_primitives::{B256, U256};
+    use reth_ethereum_primitives::EthPrimitives;
+    use reth_primitives_traits::SealedHeader;
+    use tokio::sync::broadcast;
+    use tokio::time::{sleep, Duration};
+
+    #[tokio::test]
+    async fn test_header_subscription_service() {
+        let (event_sender, _event_receiver) = broadcast::channel(16);
+        let (service, mut header_receiver) = HeaderSubscriptionService::<EthPrimitives>::new(event_sender);
+        
+        // Start the service in a background task
+        let service_handle = tokio::spawn(async move {
+            service.start().await;
+        });
+        
+        // Create a test header
+        let mut header = BlockHeader::default();
+        header.number = 100;
+        header.state_root = B256::from([0x42; 32]);
+        let sealed_header = SealedHeader::seal_slow(header);
+        
+        // Send a canonical chain committed event
+        let event = ConsensusEngineEvent::CanonicalChainCommitted(
+            Box::new(sealed_header.clone()),
+            Duration::from_millis(100)
+        );
+        
+        event_sender.send(event).unwrap();
+        
+        // Wait for the header to be received
+        sleep(Duration::from_millis(10)).await;
+        
+        // Check that we received the header
+        let received_header = header_receiver.borrow().clone();
+        assert!(received_header.is_some());
+        assert_eq!(received_header.unwrap().hash(), sealed_header.hash());
+        
+        // Clean up
+        service_handle.abort();
+    }
+    
+    #[tokio::test]
+    async fn test_header_subscription_ignores_duplicate_headers() {
+        let (event_sender, _event_receiver) = broadcast::channel(16);
+        let (service, mut header_receiver) = HeaderSubscriptionService::<EthPrimitives>::new(event_sender);
+        
+        // Start the service in a background task
+        let service_handle = tokio::spawn(async move {
+            service.start().await;
+        });
+        
+        // Create a test header
+        let mut header = BlockHeader::default();
+        header.number = 100;
+        header.state_root = B256::from([0x42; 32]);
+        let sealed_header = SealedHeader::seal_slow(header);
+        
+        // Send the same event twice
+        let event = ConsensusEngineEvent::CanonicalChainCommitted(
+            Box::new(sealed_header.clone()),
+            Duration::from_millis(100)
+        );
+        
+        event_sender.send(event.clone()).unwrap();
+        event_sender.send(event).unwrap();
+        
+        // Wait for processing
+        sleep(Duration::from_millis(10)).await;
+        
+        // Check that we only received one update
+        let received_header = header_receiver.borrow().clone();
+        assert!(received_header.is_some());
+        assert_eq!(received_header.unwrap().hash(), sealed_header.hash());
+        
+        // Clean up
+        service_handle.abort();
+    }
+}

--- a/crates/stages/stages/src/stages/snap_sync_integration_test.rs
+++ b/crates/stages/stages/src/stages/snap_sync_integration_test.rs
@@ -1,0 +1,249 @@
+//! Integration tests for snap sync with header subscription.
+
+use crate::stages::SnapSyncStage;
+use crate::stages::header_subscription::HeaderSubscriptionService;
+use reth_config::config::SnapSyncConfig;
+use reth_engine_primitives::ConsensusEngineEvent;
+use reth_ethereum_primitives::EthPrimitives;
+use reth_network_p2p::snap::client::SnapClient;
+use reth_eth_wire_types::snap::{AccountRangeMessage, GetAccountRangeMessage};
+use reth_network_p2p::{priority::Priority, error::PeerRequestResult};
+use std::sync::Arc;
+use tokio::sync::broadcast;
+use tokio::time::{sleep, Duration};
+use alloy_primitives::B256;
+use alloy_consensus::BlockHeader;
+use reth_primitives_traits::SealedHeader;
+
+/// Mock snap client for testing
+#[derive(Debug, Clone)]
+pub struct MockSnapClient;
+
+impl SnapClient for MockSnapClient {
+    type Output = std::pin::Pin<Box<dyn std::future::Future<Output = PeerRequestResult<AccountRangeMessage>> + Send + Sync + Unpin>>;
+
+    fn get_account_range_with_priority(
+        &self,
+        _request: GetAccountRangeMessage,
+        _priority: Priority,
+    ) -> Self::Output {
+        Box::pin(async move {
+            // Return a mock empty response
+            Ok((B256::ZERO, AccountRangeMessage {
+                request_id: 1,
+                accounts: vec![],
+                proof: vec![],
+            }))
+        })
+    }
+
+    fn get_storage_ranges(&self, _request: reth_eth_wire_types::snap::GetStorageRangesMessage) -> Self::Output {
+        todo!()
+    }
+
+    fn get_storage_ranges_with_priority(
+        &self,
+        _request: reth_eth_wire_types::snap::GetStorageRangesMessage,
+        _priority: Priority,
+    ) -> Self::Output {
+        todo!()
+    }
+
+    fn get_byte_codes(&self, _request: reth_eth_wire_types::snap::GetByteCodesMessage) -> Self::Output {
+        todo!()
+    }
+
+    fn get_byte_codes_with_priority(
+        &self,
+        _request: reth_eth_wire_types::snap::GetByteCodesMessage,
+        _priority: Priority,
+    ) -> Self::Output {
+        todo!()
+    }
+
+    fn get_trie_nodes(&self, _request: reth_eth_wire_types::snap::GetTrieNodesMessage) -> Self::Output {
+        todo!()
+    }
+
+    fn get_trie_nodes_with_priority(
+        &self,
+        _request: reth_eth_wire_types::snap::GetTrieNodesMessage,
+        _priority: Priority,
+    ) -> Self::Output {
+        todo!()
+    }
+}
+
+#[tokio::test]
+async fn test_snap_sync_with_header_subscription() {
+    // Create a broadcast channel for consensus engine events
+    let (event_sender, _event_receiver) = broadcast::channel(16);
+    
+    // Create snap sync config
+    let config = SnapSyncConfig {
+        enabled: true,
+        max_ranges_per_execution: 10,
+        max_response_bytes: 1000000,
+        request_timeout_seconds: 30,
+        range_size: 1000,
+        max_retries: 3,
+    };
+    
+    // Create snap client
+    let snap_client = Arc::new(MockSnapClient);
+    
+    // Create snap sync stage with header subscription
+    let (snap_sync_stage, mut header_receiver) = SnapSyncStage::with_header_subscription(
+        config,
+        snap_client,
+        event_sender.clone(),
+    );
+    
+    // Verify the stage was created with header receiver
+    assert!(snap_sync_stage.header_receiver.is_some());
+    
+    // Create a test header
+    let mut header = BlockHeader::default();
+    header.number = 100;
+    header.state_root = B256::from([0x42; 32]);
+    let sealed_header = SealedHeader::seal_slow(header);
+    
+    // Send a canonical chain committed event
+    let event = ConsensusEngineEvent::CanonicalChainCommitted(
+        Box::new(sealed_header.clone()),
+        Duration::from_millis(100)
+    );
+    
+    event_sender.send(event).unwrap();
+    
+    // Wait for the header to be received
+    sleep(Duration::from_millis(50)).await;
+    
+    // Check that the stage received the header
+    let target_state_root = snap_sync_stage.get_target_state_root();
+    assert!(target_state_root.is_some());
+    assert_eq!(target_state_root.unwrap(), sealed_header.state_root);
+    
+    // Check that the header receiver also received the update
+    let received_header = header_receiver.borrow().clone();
+    assert!(received_header.is_some());
+    assert_eq!(received_header.unwrap().hash(), sealed_header.hash());
+}
+
+#[tokio::test]
+async fn test_snap_sync_state_root_change_detection() {
+    // Create a broadcast channel for consensus engine events
+    let (event_sender, _event_receiver) = broadcast::channel(16);
+    
+    // Create snap sync config
+    let config = SnapSyncConfig {
+        enabled: true,
+        max_ranges_per_execution: 10,
+        max_response_bytes: 1000000,
+        request_timeout_seconds: 30,
+        range_size: 1000,
+        max_retries: 3,
+    };
+    
+    // Create snap client
+    let snap_client = Arc::new(MockSnapClient);
+    
+    // Create snap sync stage with header subscription
+    let (mut snap_sync_stage, _header_receiver) = SnapSyncStage::with_header_subscription(
+        config,
+        snap_client,
+        event_sender.clone(),
+    );
+    
+    // Initially no state root
+    assert!(snap_sync_stage.get_target_state_root().is_none());
+    
+    // Create first header
+    let mut header1 = BlockHeader::default();
+    header1.number = 100;
+    header1.state_root = B256::from([0x42; 32]);
+    let sealed_header1 = SealedHeader::seal_slow(header1);
+    
+    // Send first event
+    let event1 = ConsensusEngineEvent::CanonicalChainCommitted(
+        Box::new(sealed_header1.clone()),
+        Duration::from_millis(100)
+    );
+    event_sender.send(event1).unwrap();
+    
+    // Wait for processing
+    sleep(Duration::from_millis(50)).await;
+    
+    // Check state root
+    let state_root1 = snap_sync_stage.get_target_state_root();
+    assert!(state_root1.is_some());
+    assert_eq!(state_root1.unwrap(), B256::from([0x42; 32]));
+    
+    // Test state root change detection
+    assert!(snap_sync_stage.has_state_root_changed(None));
+    assert!(!snap_sync_stage.has_state_root_changed(state_root1));
+    
+    // Create second header with different state root
+    let mut header2 = BlockHeader::default();
+    header2.number = 101;
+    header2.state_root = B256::from([0x43; 32]);
+    let sealed_header2 = SealedHeader::seal_slow(header2);
+    
+    // Send second event
+    let event2 = ConsensusEngineEvent::CanonicalChainCommitted(
+        Box::new(sealed_header2.clone()),
+        Duration::from_millis(100)
+    );
+    event_sender.send(event2).unwrap();
+    
+    // Wait for processing
+    sleep(Duration::from_millis(50)).await;
+    
+    // Check new state root
+    let state_root2 = snap_sync_stage.get_target_state_root();
+    assert!(state_root2.is_some());
+    assert_eq!(state_root2.unwrap(), B256::from([0x43; 32]));
+    
+    // Test state root change detection
+    assert!(snap_sync_stage.has_state_root_changed(state_root1));
+    assert!(!snap_sync_stage.has_state_root_changed(state_root2));
+}
+
+#[tokio::test]
+async fn test_header_subscription_service_directly() {
+    // Create a broadcast channel for consensus engine events
+    let (event_sender, _event_receiver) = broadcast::channel(16);
+    
+    // Create header subscription service
+    let (header_service, mut header_receiver) = HeaderSubscriptionService::<EthPrimitives>::new(event_sender.clone());
+    
+    // Start the service in a background task
+    let service_handle = tokio::spawn(async move {
+        header_service.start().await;
+    });
+    
+    // Create a test header
+    let mut header = BlockHeader::default();
+    header.number = 100;
+    header.state_root = B256::from([0x42; 32]);
+    let sealed_header = SealedHeader::seal_slow(header);
+    
+    // Send a canonical chain committed event
+    let event = ConsensusEngineEvent::CanonicalChainCommitted(
+        Box::new(sealed_header.clone()),
+        Duration::from_millis(100)
+    );
+    
+    event_sender.send(event).unwrap();
+    
+    // Wait for the header to be received
+    sleep(Duration::from_millis(50)).await;
+    
+    // Check that we received the header
+    let received_header = header_receiver.borrow().clone();
+    assert!(received_header.is_some());
+    assert_eq!(received_header.unwrap().hash(), sealed_header.hash());
+    
+    // Clean up
+    service_handle.abort();
+}


### PR DESCRIPTION
Integrate head header subscription into the snap sync stage to update target state roots from the consensus engine, fulfilling issue #17177.

---
<a href="https://cursor.com/background-agent?bcId=bc-a9392ada-117f-4a61-a7ad-cdb147828623"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a9392ada-117f-4a61-a7ad-cdb147828623"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

